### PR TITLE
Fix small typo with move function

### DIFF
--- a/lib/flop.js
+++ b/lib/flop.js
@@ -67,7 +67,7 @@
             if (!error || error.code !== 'EXDEV')
                 callback(error);
             else
-                flop.cp(from, to, function(error) {
+                flop.copy(from, to, function(error) {
                     if (error)
                         callback(error);
                     else


### PR DESCRIPTION
After a recent upgrade of cloudcmd, I noticed it was unable to move files.

A quick review of flop.js pointed me to this syntax error.

The same change made on my system fixed the issue I was having.

I'm not sure when this bug was introduced or why it only recently manifested itself for me.
