### PR TITLE
Fixed compatible with Node v12

### DIFF
--- a/lib/flop.js
+++ b/lib/flop.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {rename, mkdir} = require("fs").promises;
+const {rename, mkdir} = require('fs').promises;
 const path = require('path');
 const {promisify} = require('util');
 

--- a/lib/flop.js
+++ b/lib/flop.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {rename, mkdir} = require('fs/promises');
+const {rename, mkdir} = require("fs").promises;
 const path = require('path');
 const {promisify} = require('util');
 


### PR DESCRIPTION
Node version 12.x doesn't support `require("fs/promises");`,

so it has to be changed to `require("fs").promises;` for both Node 12.x, 14.x.